### PR TITLE
Publish TSMBIOS libary as a package for Delphinus package manager

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,10 @@
+{
+  "id": "{B6E68F06-812B-4CF3-8C81-B9D7219AAAFB}",
+  "name": "TSMBIOS",
+  "picture": "images\\logo.png",
+  "platforms": "Win32;Win64",
+  "package_compiler_min": 13,
+  "package_compiler_max": 32,
+  "compiler_min": 13,
+  "compiler_max": 32
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,14 @@
+{
+  "search_pathes": [{
+    "pathes": "Common",
+    "platforms": "Win32;Win64"
+  }],
+  "browsing_pathes": [{
+    "pathes": "Common",
+    "platforms": "Win32;Win64"
+  }],
+  "source_folders": [{
+    "folder": ".",
+    "recursive": true
+  }]
+}

--- a/README.md
+++ b/README.md
@@ -136,3 +136,7 @@ end.
 
 ## Help Insight
 ![Help Insight](https://github.com/RRUZ/tsmbios/blob/master/images/preview.png)
+
+
+## Other
+You can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install TSMBIOS as a package there. (Delphinus-Support)


### PR DESCRIPTION
It's just a little idea to consider.
Maybe the whole Delphinus project (https://github.com/Memnarch/Delphinus) is not so mature but I think it's just nice idea because it can work directly with GitHub (in opposite to GetIt).

Why?
 - to spread a word about TSMBIOS
 - to be able to add TSMBIOSas dependency for Delphinus packages.
 - to make updates quick & easy

The line with keyword "Delphinus-Support" in readme is needed to find TSMBIOS repository via GitHub API.