### PR TITLE
Add the description for AMD Ryzen (ProcessorFamily = 107)

### DIFF
--- a/Common/uSMBIOS.pas
+++ b/Common/uSMBIOS.pas
@@ -5771,7 +5771,11 @@ begin
         Result := '68020';
       101 :
         Result := '68030';
-      102 .. 111 :
+      102 .. 106 :
+        Result := 'Available for assignment';
+      107 :
+        Result := 'AMD Ryzen Processor Family';
+      108 .. 111 :
         Result := 'Available for assignment';
       112 :
         Result := 'Hobbit Family';


### PR DESCRIPTION
Add the description for ProcessorFamily = 107: AMD Ryzen Processor Family

Tested on AMD Ryzen™ 5 2600
https://www.amd.com/en/support/downloads/drivers.html/processors/ryzen/ryzen-2000-series/amd-ryzen-5-2600.html